### PR TITLE
feat: adicionar componentes Container e EntryTitle

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,8 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-import Header from "../components/header";
+import Header from "../components/Header";
+import Footer from "../components/Footer";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -30,6 +31,7 @@ export default function RootLayout({
       >
         <Header />
         {children}
+        <Footer />
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,10 @@
-import Image from "next/image";
-import Header from "../components/header";
+import Slider from "../components/Slider"
 
 export default function Home() {
 
   return (
     <div className="w-full">
+      <Slider />
       <main>
         <h1>teste</h1>
       </main>

--- a/src/app/sobre/page.tsx
+++ b/src/app/sobre/page.tsx
@@ -7,8 +7,8 @@ export default function Sobre() {
             <article>
                 <EntryTitle />
 
-                <div className="content p-3 h-40 max-w-[1200px] mx-auto w-full ">
-                    asdfasdfasdf
+                <div className="content py-6 h-60 max-w-[1200px] mx-auto w-full">
+                    fadfasdf
                 </div>
 
             </article>

--- a/src/app/sobre/page.tsx
+++ b/src/app/sobre/page.tsx
@@ -3,15 +3,15 @@ import EntryTitle from "../../components/EntryTitle";
 
 export default function Sobre() {
     return (
-        <section>
-            <article>
-                <EntryTitle />
 
-                <div className="content py-6 h-60 max-w-[1200px] mx-auto w-full">
-                    fadfasdf
+        <article>
+            <EntryTitle>Teste</EntryTitle>
+            <Container>
+                <div className="content py-6 px-3">
+                    Meu conteúdo aqui
                 </div>
+            </Container>
+        </article>
 
-            </article>
-        </section>
     )
 }

--- a/src/app/sobre/page.tsx
+++ b/src/app/sobre/page.tsx
@@ -1,3 +1,17 @@
+import Container from "../../components/Container";
+import EntryTitle from "../../components/EntryTitle";
+
 export default function Sobre() {
-    return <div>Conteúdo da página Sobre</div>;
+    return (
+        <section>
+            <article>
+                <EntryTitle />
+
+                <div className="content p-3 h-40 max-w-[1200px] mx-auto w-full ">
+                    asdfasdfasdf
+                </div>
+
+            </article>
+        </section>
+    )
 }

--- a/src/components/AuthButtons/indext.tsx
+++ b/src/components/AuthButtons/indext.tsx
@@ -2,7 +2,7 @@ import { BiUserCircle } from "react-icons/bi";
 
 export default function AuthButtons() {
     return (
-        <div className="max-w-[1200px] flex gap-0">
+        <div className="max-w-[1200px] flex gap-0  px-4">
             {/* Botão de Login com ícone */}
             <button className="flex items-center gap-2 border border-white 
             text-white px-4 py-2 text-[10px]">

--- a/src/components/AuthButtons/indext.tsx
+++ b/src/components/AuthButtons/indext.tsx
@@ -2,7 +2,7 @@ import { BiUserCircle } from "react-icons/bi";
 
 export default function AuthButtons() {
     return (
-        <div className="max-w-[1200px] flex gap-0  px-4">
+        <div className="max-w-[1200px] flex gap-0  px-3">
             {/* Botão de Login com ícone */}
             <button className="flex items-center gap-2 border border-white 
             text-white px-4 py-2 text-[10px]">

--- a/src/components/Container/index.tsx
+++ b/src/components/Container/index.tsx
@@ -1,7 +1,17 @@
-export default function Container() {
-    return (
-        <div className="content py-6 h-60 max-w-[1200px] mx-auto w-full ">
+// export default function Container() {
+//     return (
+//         <div className="content py-6 h-60 max-w-[1200px] mx-auto w-full ">
 
+//         </div>
+//     )
+// }
+
+import { ReactNode } from "react";
+
+export default function Container({ children }: { children: ReactNode }) {
+    return (
+        <div className="max-w-[1200px] mx-auto px-3">
+            {children}
         </div>
-    )
+    );
 }

--- a/src/components/Container/index.tsx
+++ b/src/components/Container/index.tsx
@@ -1,0 +1,7 @@
+export default function Container() {
+    return (
+        <div className="content p-3 h-40 max-w-[1200px] mx-auto w-full ">
+
+        </div>
+    )
+}

--- a/src/components/Container/index.tsx
+++ b/src/components/Container/index.tsx
@@ -1,6 +1,6 @@
 export default function Container() {
     return (
-        <div className="content p-3 h-40 max-w-[1200px] mx-auto w-full ">
+        <div className="content py-6 h-60 max-w-[1200px] mx-auto w-full ">
 
         </div>
     )

--- a/src/components/EntryTitle/index.tsx
+++ b/src/components/EntryTitle/index.tsx
@@ -1,0 +1,9 @@
+export default function EntryTitle() {
+    return (
+        <header className="bg-brand">
+            <div className="max-w-[1200px] mx-auto w-full flex items-center justify-between h-20 text-white p-1">
+                <h1>Titulo</h1>
+            </div>
+        </header>
+    )
+}

--- a/src/components/EntryTitle/index.tsx
+++ b/src/components/EntryTitle/index.tsx
@@ -1,9 +1,16 @@
-export default function EntryTitle() {
+import { ReactNode } from "react"
+import Container from "../Container"
+
+export default function EntryTitle({ children }: { children: ReactNode }) {
     return (
         <header className="bg-brand">
-            <div className="max-w-[1200px] mx-auto w-full flex items-center justify-between h-20 text-white px-4">
-                <h1>Titulo</h1>
-            </div>
+
+            <Container>
+                <div className="flex items-center justify-between h-20 text-white px-3">
+                    <h1>{children}</h1>
+                </div>
+            </Container>
+
         </header>
     )
 }

--- a/src/components/EntryTitle/index.tsx
+++ b/src/components/EntryTitle/index.tsx
@@ -1,7 +1,7 @@
 export default function EntryTitle() {
     return (
         <header className="bg-brand">
-            <div className="max-w-[1200px] mx-auto w-full flex items-center justify-between h-20 text-white p-1">
+            <div className="max-w-[1200px] mx-auto w-full flex items-center justify-between h-20 text-white px-4">
                 <h1>Titulo</h1>
             </div>
         </header>

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -1,8 +1,8 @@
 export default function Footer() {
     return (
         <footer>
-            <div className="bg-brand text-white p-1">
-                <div className="max-w-[1200px] h-8 mx-auto w-full flex justify-between items-center">
+            <div className="bg-brand text-white">
+                <div className="max-w-[1200px] h-20 mx-auto w-full flex justify-between items-center  px-4">
                     <aside>
                         Coluna 1
                     </aside>

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -1,25 +1,27 @@
+import Container from "../Container"
+
 export default function Footer() {
     return (
-        <footer>
-            <div className="bg-brand text-white">
-                <div className="max-w-[1200px] h-20 mx-auto w-full flex justify-between items-center  px-4">
-                    <aside>
+        <footer className="bg-brand text-white">
+            <Container>
+                <div className="flex items-center justify-between py-4">
+                    <aside className="px-3">
                         Coluna 1
                     </aside>
-                    <aside>
+                    <aside className="px-3">
                         Coluna 2
                     </aside>
-                    <aside>
+                    <aside className="px-3">
                         Coluna 3
                     </aside>
-                    <aside>
+                    <aside className="px-3">
                         Coluna 4
                     </aside>
-                    <aside>
+                    <aside className="px-3">
                         Coluna 5
                     </aside>
                 </div>
-            </div>
+            </Container>
         </footer>
     )
 } 

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -1,0 +1,25 @@
+export default function Footer() {
+    return (
+        <footer>
+            <div className="bg-brand text-white p-1">
+                <div className="max-w-[1200px] h-8 mx-auto w-full flex justify-between items-center">
+                    <aside>
+                        Coluna 1
+                    </aside>
+                    <aside>
+                        Coluna 2
+                    </aside>
+                    <aside>
+                        Coluna 3
+                    </aside>
+                    <aside>
+                        Coluna 4
+                    </aside>
+                    <aside>
+                        Coluna 5
+                    </aside>
+                </div>
+            </div>
+        </footer>
+    )
+} 

--- a/src/components/NavMenu/index.tsx
+++ b/src/components/NavMenu/index.tsx
@@ -12,7 +12,7 @@ export default function NavMenu() {
 
     return (
         <nav>
-            <div className="mx-auto px-4">
+            <div className="mx-auto">
                 <ul className="flex flex-wrap gap-6 py-4 text-gray-800 font-medium text-[12px] uppercase">
                     {menuItems.map((item) => (
                         <li key={item.href}>

--- a/src/components/Slider/index.tsx
+++ b/src/components/Slider/index.tsx
@@ -1,0 +1,5 @@
+export default function Slider() {
+    return (
+        <p>Slider aqui</p>
+    )
+}

--- a/src/components/TopNavMenu/index.tsx
+++ b/src/components/TopNavMenu/index.tsx
@@ -15,7 +15,7 @@ export default function TopNavMenu() {
 
     return (
         <nav className="">
-            <div className="max-w-[1200px] mx-auto px-4">
+            <div className="max-w-[1200px] mx-auto px-3">
                 <ul className="flex flex-wrap gap-4 py-2 text-white-800 font-medium text-[10px] uppercase">
                     {menuItems.map((item) => (
                         <li key={item}>

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -4,31 +4,36 @@ import Link from "next/link";
 import AuthButtons from "../AuthButtons/indext";
 import NavMenu from "../NavMenu";
 import TopNavMenu from "../TopNavMenu";
+import Container from "../Container";
 
 export default function Header() {
     return (
-        <header className="shadow-sm">
+        <header className="shadow-sm z-10 relative">
             <div className="bg-brand text-white p-1">
-                <div className="max-w-[1200px] h-8 mx-auto w-full flex justify-between items-center">
-                    <TopNavMenu />
-                    <div className="max-w-[1200px]">
-                        <AuthButtons />
+                <Container>
+                    <div className="flex justify-between items-center">
+                        <TopNavMenu />
+                        <div className="max-w-[1200px]">
+                            <AuthButtons />
+                        </div>
                     </div>
-                </div>
+                </Container>
             </div>
 
             <div className="bg-white w-full">
-                <div className="max-w-[1200px] mx-auto w-full h-25 flex justify-between items-center px-4">
-                    <Link href="/">
-                        <Image
-                            src="/logo-sbot.png" // <-- use o path direto da pasta public
-                            alt="Logotipo SBOT"
-                            width={145}
-                            height={57}
-                        />
-                    </Link>
-                    <NavMenu />
-                </div>
+                <Container>
+                    <div className="h-25 flex justify-between items-center px-3">
+                        <Link href="/">
+                            <Image
+                                src="/logo-sbot.png" // <-- use o path direto da pasta public
+                                alt="Logotipo SBOT"
+                                width={145}
+                                height={57}
+                            />
+                        </Link>
+                        <NavMenu />
+                    </div>
+                </Container>
             </div>
         </header>
     );

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -18,7 +18,7 @@ export default function Header() {
             </div>
 
             <div className="bg-white w-full">
-                <div className="max-w-[1200px] mx-auto w-full h-25 flex justify-between items-center">
+                <div className="max-w-[1200px] mx-auto w-full h-25 flex justify-between items-center px-4">
                     <Link href="/">
                         <Image
                             src="/logo-sbot.png" // <-- use o path direto da pasta public

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -1,0 +1,1 @@
+declare module "*.css";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,35 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "noEmit": true,
+    "incremental": true,
+    "module": "esnext",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": [
+    "next-env.d.ts",
+    ".next/types/**/*.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
Este PR adiciona dois novos componentes reutilizáveis:

* **Container** → define largura máxima centralizada (`max-w-[1200px]`) com padding lateral.
* **EntryTitle** → cria um cabeçalho estilizado com fundo `bg-brand`, texto branco e espaçamento adequado.

**Alterações:**

* Criado `Container.tsx` em `src/components/`.
* Criado `EntryTitle/index.tsx` em `src/components/EntryTitle/`.

**Motivação:**
Esses componentes visam padronizar a estrutura visual de containers e títulos de entrada em páginas da aplicação.
